### PR TITLE
Multiple criteria unicity

### DIFF
--- a/product/src/main/java/fr/gouv/education/acrennes/alambic/utils/Functions.java
+++ b/product/src/main/java/fr/gouv/education/acrennes/alambic/utils/Functions.java
@@ -382,8 +382,8 @@ public class Functions {
                     final String attributeName = tokensMatcher.group(2);
                     final String currentValuePattern = tokensMatcher.group(3);
                     reqAttributes.add(attributeName);
-                    if (StringUtils.isNotBlank(shortestCommonValuePattern) && !shortestCommonValuePattern.contains(currentValuePattern) && !currentValuePattern.contains(shortestCommonValuePattern)) {
-                        LOG.error("All unicity patterns must share a common part within the request. " +
+                    if (StringUtils.isNotBlank(shortestCommonValuePattern) && !shortestCommonValuePattern.startsWith(currentValuePattern) && !currentValuePattern.startsWith(shortestCommonValuePattern)) {
+                        LOG.error("All unicity patterns must share a common root (prefix) within the request. This root usually ends with a star (*)." +
                                 "But found two unrelated patterns: '" + shortestCommonValuePattern + "' and '" + attributeName + "=" + currentValuePattern + "' in the request '" + searchString + "'. " +
                                 "Pattern '" + currentValuePattern + "' defined for attribute '" + attributeName + "', will be used for LDAP request, but ignored for unique value generation.");
                         continue; // Read the next pattern
@@ -450,8 +450,8 @@ public class Functions {
                             for (int i = 1; i <= existingValuesInLowerCase.size(); i++) {
                                 // finalUniqueValue is a local constant copy of uniqueValue to allow its use in the following lambda expression
                                 final String finalUniqueValue = uniqueValue;
-                                // If there is not a value in "existingValuesInLowerCase" that contains candidate "uniqueValue", so we can use the latter as result
-                                if (existingValuesInLowerCase.stream().noneMatch(existingValue -> existingValue.contains(finalUniqueValue.toLowerCase()))) {
+                                // If there is not a value in "existingValuesInLowerCase" that starts with candidate "uniqueValue", so we can use the latter as result
+                                if (existingValuesInLowerCase.stream().noneMatch(existingValue -> existingValue.startsWith(finalUniqueValue.toLowerCase()))) {
                                     // Found the unique value
                                     LOG.debug("Found the unique value '" + uniqueValue + "'");
                                     break;

--- a/product/src/main/java/fr/gouv/education/acrennes/alambic/utils/Functions.java
+++ b/product/src/main/java/fr/gouv/education/acrennes/alambic/utils/Functions.java
@@ -37,9 +37,12 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Hashtable;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -361,10 +364,9 @@ public class Functions {
         return rdn;
     }
 
-    @SuppressWarnings("unchecked")
     private String unicity(final String searchString, final CallStack callStack) throws AlambicException {
         String uniqueValue = "";
-        String valuePattern = "";
+        String shortestCommonValuePattern = "";
         NamingEnumeration<SearchResult> resultSet = null;
 
         try {
@@ -374,37 +376,45 @@ public class Functions {
             if (unicityMatcher.find()) {
                 final Pattern tokensPattern = Pattern.compile(UNICITY_PATTERN_TOKEN);
                 final Matcher tokensMatcher = tokensPattern.matcher(unicityMatcher.group(7));
-                final List<String> reqAttributes = new ArrayList<>();
+                final Set<String> reqAttributes = new LinkedHashSet<>(); // use a Set to avoid duplicated values
+                // validate all patterns in "searchString" and keep the shortest common one, also keep an ordered set of all attribute names in "reqAttributes"
                 while (tokensMatcher.find()) {
-                    reqAttributes.add(tokensMatcher.group(2));
-                    if (StringUtils.isNotBlank(valuePattern) && !valuePattern.equals(tokensMatcher.group(3))) {
-                        LOG.error("All unicity patterns must be the same within the request. But found two different ones '" + valuePattern + "' && '" + tokensMatcher.group(3) + "' in the request '" + searchString + "'");
-                        break;
+                    final String attributeName = tokensMatcher.group(2);
+                    final String currentValuePattern = tokensMatcher.group(3);
+                    reqAttributes.add(attributeName);
+                    if (StringUtils.isNotBlank(shortestCommonValuePattern) && !shortestCommonValuePattern.contains(currentValuePattern) && !currentValuePattern.contains(shortestCommonValuePattern)) {
+                        LOG.error("All unicity patterns must share a common part within the request. " +
+                                "But found two unrelated patterns: '" + shortestCommonValuePattern + "' and '" + attributeName + "=" + currentValuePattern + "' in the request '" + searchString + "'. " +
+                                "Pattern '" + currentValuePattern + "' defined for attribute '" + attributeName + "', will be used for LDAP request, but ignored for unique value generation.");
+                        continue; // Read the next pattern
                     }
-                    valuePattern = tokensMatcher.group(3);
+                    // If pattern is not yet defined or a shorter pattern is found, define current pattern as shortestCommonValuePattern
+                    if (StringUtils.isBlank(shortestCommonValuePattern) || currentValuePattern.length() < shortestCommonValuePattern.length()) {
+                        shortestCommonValuePattern = currentValuePattern;
+                    }
                 }
 
                 final String generatorValue = unicityMatcher.group(2);
-                uniqueValue = valuePattern.replaceAll("\\*", ((StringUtils.isNotBlank(generatorValue) ? generatorValue : "")));
+                uniqueValue = shortestCommonValuePattern.replace("*", (StringUtils.isNotBlank(generatorValue) ? generatorValue : ""));
                 if (LOG.isDebugEnabled()) {
-                    LOG.debug("Check unicity criteria on the attribut(s) '" + reqAttributes + "' (candidate value is '" + uniqueValue + "'");
+                    LOG.debug("Check unicity criteria on the attribut(s) '" + reqAttributes + "' (candidate value for pattern '" + shortestCommonValuePattern + "' is '" + uniqueValue + "'");
                 }
 
                 if (StringUtils.isNotBlank(uniqueValue)) {
                     // Search occurrences within LDAP (sub tree scope is used)
                     final SearchControls searchControls = new SearchControls();
                     searchControls.setSearchScope(SearchControls.SUBTREE_SCOPE);
-                    final Hashtable<String, String> environment = new Hashtable<>();
+                    final Properties environment = new Properties(); // using Properties allows to ensure the configuration values are typed as String & removes warning java:S1149
                     if (StringUtils.isNotBlank(unicityMatcher.group(5)) && StringUtils.isNotBlank(unicityMatcher.group(6))) {
                         LOG.debug("Using principal " + unicityMatcher.group(4));
-                        environment.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
-                        environment.put(Context.PROVIDER_URL, unicityMatcher.group(8));
-                        environment.put(Context.SECURITY_PRINCIPAL, unicityMatcher.group(4));
-                        environment.put(Context.SECURITY_CREDENTIALS, unicityMatcher.group(6));
+                        environment.setProperty(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
+                        environment.setProperty(Context.PROVIDER_URL, unicityMatcher.group(8));
+                        environment.setProperty(Context.SECURITY_PRINCIPAL, unicityMatcher.group(4));
+                        environment.setProperty(Context.SECURITY_CREDENTIALS, unicityMatcher.group(6));
                     } else {
                         LOG.debug("No credential or password provided");
                     }
-                    LOG.debug("Recherche : " + unicityMatcher.group(7));
+                    LOG.debug("LDAP search query: " + unicityMatcher.group(7));
                     resultSet = getDirContext(environment).search(unicityMatcher.group(7), "", searchControls);
 
                     if ((null != resultSet) && resultSet.hasMore()) {
@@ -412,29 +422,36 @@ public class Functions {
                         final CallStack ifc = (!callStack.getStack().isEmpty()) ? callStack.getStack().get(0) : null;
                         if ((null != ifc) && StringUtils.isBlank(unicityMatcher.group(1))) {
                             // Ask the inner function to give a new candidate value
-                            final String newCandidate = searchFunctions(ifc.getFulltext(), new HashMap<String, String>(), callStack);
+                            final String newCandidate = searchFunctions(ifc.getFulltext(), new HashMap<>(), callStack);
                             uniqueValue = unicity(searchString.replace(uniqueValue, newCandidate), callStack);
                         } else {
                             // No inner function was used to build the candidate value: compute the new unique value via an
                             // incremental suffix and based on the previous search result
-                            final ArrayList<String> list = new ArrayList<>();
+                            // First retrieve all the already existing values in "reqAttributes" fields of the LDAP resultSet, including the multi-values ones
+                            final Set<String> existingValuesInLowerCase = new HashSet<>(); // use a Set to avoid duplicated values
                             while (resultSet.hasMore()) {
                                 final SearchResult result = resultSet.next();
                                 LOG.debug("The following LDAP entity matches the search string '" + searchString + "', entity: " + result.getName());
                                 final Attributes attributes = result.getAttributes();
                                 for (final String attribute : reqAttributes) {
                                     if (null != attributes.get(attribute)) {
-                                        final NamingEnumeration<String> values = (NamingEnumeration<String>) attributes.get(attribute).getAll();
+                                        final NamingEnumeration<?> values = attributes.get(attribute).getAll();
                                         while (values.hasMore()) {
-                                            list.add(values.next().toLowerCase());
+                                            final Object value = values.next();
+                                            if (value instanceof String) {
+                                                existingValuesInLowerCase.add(((String) value).toLowerCase());
+                                            }
                                         }
                                     }
                                 }
                             }
 
-                            // Compute the unique value
-                            for (int i = 1; i <= list.size(); i++) {
-                                if (!list.contains(uniqueValue.toLowerCase())) {
+                            // Compute the unique value, loop at most "existingValuesInLowerCase.size()" times, as the worst case occurs when all candidate values already exist
+                            for (int i = 1; i <= existingValuesInLowerCase.size(); i++) {
+                                // finalUniqueValue is a local constant copy of uniqueValue to allow its use in the following lambda expression
+                                final String finalUniqueValue = uniqueValue;
+                                // If there is not a value in "existingValuesInLowerCase" that contains candidate "uniqueValue", so we can use the latter as result
+                                if (existingValuesInLowerCase.stream().noneMatch(existingValue -> existingValue.contains(finalUniqueValue.toLowerCase()))) {
                                     // Found the unique value
                                     LOG.debug("Found the unique value '" + uniqueValue + "'");
                                     break;
@@ -443,10 +460,10 @@ public class Functions {
                                     String newCandidate = String.valueOf(i);
                                     if (null != ifc) {
                                         // Ask the inner function to give a new candidate value
-                                        newCandidate = searchFunctions(ifc.getFulltext(), new HashMap<String, String>(), callStack);
+                                        newCandidate = searchFunctions(ifc.getFulltext(), new HashMap<>(), callStack);
                                     }
                                     // Compute new candidate value
-                                    uniqueValue = valuePattern.replace("*", newCandidate);
+                                    uniqueValue = shortestCommonValuePattern.replace("*", newCandidate);
                                 }
                             }
                         }

--- a/product/src/test/java/fr/gouv/education/acrennes/alambic/freemarker/FunctionsTest.java
+++ b/product/src/test/java/fr/gouv/education/acrennes/alambic/freemarker/FunctionsTest.java
@@ -364,4 +364,468 @@ public class FunctionsTest {
 		Functions.getInstance().executeAllFunctions("(UNICITY)candidate=\"(STRINGFORMAT)pattern=%07d;values=(INCREMENT)1(/INCREMENT);types=Integer(/STRINGFORMAT)\",login=\"cn=TechnicalPrincipal\",password=\"TopSecret\"|search=ldap://ldap-pp.in.ac-rennes.fr:389/ou=personnes,dc=ent-bretagne,dc=fr??sub?(&amp;(fonctm=EXTACA)(employeeNumber=14V*EXT))(/UNICITY)");
 	}
 
+	/* test use case: check unicity function, multi-criteria, multi-pattern request, happy path with evenly distributed sequential values, use next value  */
+	@Test
+	public void test20() {
+		try {
+			PowerMockito.when(mockedDirContext.search(Matchers.anyString(), Matchers.anyString(), Matchers.any(SearchControls.class))).
+					thenReturn(getResultSet(new String[] {
+							"uid=marge.simpson;uidinit=marge.simpson",
+							"uid=marge.simpson1;uidinit=marge.simpson1",
+							"uid=marge.simpson2;uidinit=marge.simpson2",
+							"uid=marge.simpson3;uidinit=marge.simpson3"
+					}));
+
+			final String value = Functions.getInstance().executeAllFunctions(
+					"(UNICITY)" +
+							"ldap://ldap-pp.in.ac-rennes.fr:389/ou=personnes,dc=ent-bretagne,dc=fr??sub?" +
+							"(&(|(uid=marge.simpson*)(uidinit=marge.simpson*))(territorycode=014))" +
+							"(/UNICITY)"
+			);
+			Assert.assertEquals("marge.simpson4", value);
+		} catch (final Exception e) {
+			System.out.println(e.getMessage());
+			Assert.fail();
+		}
+	}
+
+	/* test use case: check unicity function, multi-criteria, multi-pattern request, happy path with evenly distributed sequential values, fill the gap  */
+	@Test
+	public void test21() {
+		try {
+			PowerMockito.when(mockedDirContext.search(Matchers.anyString(), Matchers.anyString(), Matchers.any(SearchControls.class))).
+					thenReturn(getResultSet(new String[] {
+							"uid=marge.simpson;uidinit=marge.simpson",
+							"uid=marge.simpson1;uidinit=marge.simpson1",
+							"uid=marge.simpson2;uidinit=marge.simpson2",
+							"uid=marge.simpson4;uidinit=marge.simpson4"
+					}));
+
+			final String value = Functions.getInstance().executeAllFunctions(
+					"(UNICITY)" +
+							"ldap://ldap-pp.in.ac-rennes.fr:389/ou=personnes,dc=ent-bretagne,dc=fr??sub?" +
+							"(&(|(uid=marge.simpson*)(uidinit=marge.simpson*))(territorycode=014))" +
+							"(/UNICITY)"
+			);
+			Assert.assertEquals("marge.simpson3", value);
+		} catch (final Exception e) {
+			System.out.println(e.getMessage());
+			Assert.fail();
+		}
+	}
+
+	/* test use case: check unicity function, multi-criteria, multi-pattern request, not evenly distributed sequential values, use next value  */
+	@Test
+	public void test22() {
+		try {
+			PowerMockito.when(mockedDirContext.search(Matchers.anyString(), Matchers.anyString(), Matchers.any(SearchControls.class))).
+					thenReturn(getResultSet(new String[] {
+							"uid=marge.simpson;uidinit=marge.simpson",
+							"uid=marge.simpson1;uidinit=marge.simpson2",
+							"uid=marge.simpson2;uidinit=marge.simpson3",
+							"uid=marge.simpson4;uidinit=marge.simpson4"
+					}));
+
+			final String value = Functions.getInstance().executeAllFunctions(
+					"(UNICITY)" +
+							"ldap://ldap-pp.in.ac-rennes.fr:389/ou=personnes,dc=ent-bretagne,dc=fr??sub?" +
+							"(&(|(uid=marge.simpson*)(uidinit=marge.simpson*))(territorycode=014))" +
+							"(/UNICITY)"
+			);
+			Assert.assertEquals("marge.simpson5", value);
+		} catch (final Exception e) {
+			System.out.println(e.getMessage());
+			Assert.fail();
+		}
+	}
+
+	/* test use case: check unicity function, multi-criteria, multi-pattern request, not evenly distributed sequential values, fill the gap */
+	@Test
+	public void test23() {
+		try {
+			PowerMockito.when(mockedDirContext.search(Matchers.anyString(), Matchers.anyString(), Matchers.any(SearchControls.class))).
+					thenReturn(getResultSet(new String[] {
+							"uid=marge.simpson;uidinit=marge.simpson",
+							"uid=marge.simpson1;uidinit=marge.simpson2",
+							"uid=marge.simpson2;uidinit=marge.simpson4",
+							"uid=marge.simpson4;uidinit=marge.simpson5"
+					}));
+
+			final String value = Functions.getInstance().executeAllFunctions(
+					"(UNICITY)" +
+							"ldap://ldap-pp.in.ac-rennes.fr:389/ou=personnes,dc=ent-bretagne,dc=fr??sub?" +
+							"(&(|(uid=marge.simpson*)(uidinit=marge.simpson*))(territorycode=014))" +
+							"(/UNICITY)"
+			);
+			Assert.assertEquals("marge.simpson3", value);
+		} catch (final Exception e) {
+			System.out.println(e.getMessage());
+			Assert.fail();
+		}
+	}
+
+	/* test use case: check unicity function, multi-criteria, multi-pattern request, happy path with evenly distributed sequential values, use next value  */
+	@Test
+	public void test24() {
+		try {
+			PowerMockito.when(mockedDirContext.search(Matchers.anyString(), Matchers.anyString(), Matchers.any(SearchControls.class))).
+					thenReturn(getResultSet(new String[] {
+							"uid=marge.simpson;uidinit=marge.simpson;ENTPersonLogin=marge.simpson@014",
+							"uid=marge.simpson1;uidinit=marge.simpson1;ENTPersonLogin=marge.simpson1@014",
+							"uid=marge.simpson2;uidinit=marge.simpson2;ENTPersonLogin=marge.simpson2@014",
+							"uid=marge.simpson3;uidinit=marge.simpson3;ENTPersonLogin=marge.simpson3@014"
+					}));
+
+			final String value = Functions.getInstance().executeAllFunctions(
+					"(UNICITY)" +
+							"ldap://ldap-pp.in.ac-rennes.fr:389/ou=personnes,dc=ent-bretagne,dc=fr??sub?" +
+							"(&(|(uid=marge.simpson*)(uidinit=marge.simpson*)(ENTPersonLogin=marge.simpson*@014))(territorycode=014))" +
+							"(/UNICITY)"
+			);
+			Assert.assertEquals("marge.simpson4", value);
+		} catch (final Exception e) {
+			System.out.println(e.getMessage());
+			Assert.fail();
+		}
+	}
+
+	/* test use case: check unicity function, multi-criteria, happy path with evenly distributed sequential values, fill the gap */
+	@Test
+	public void test25() {
+		try {
+			// missing :
+			// uid=[marge.simpson2]
+			// uidinit=[marge.simpson2]
+			// ENTPersonLogin=[marge.simpson2@014]
+			PowerMockito.when(mockedDirContext.search(Matchers.anyString(), Matchers.anyString(), Matchers.any(SearchControls.class))).
+					thenReturn(getResultSet(new String[] {
+							"uid=marge.simpson;uidinit=marge.simpson;ENTPersonLogin=marge.simpson@014",
+							"uid=marge.simpsonian1;uidinit=marge.simpsonian1;ENTPersonLogin=marge.simpsonian1@014",
+							"uid=marge.simpsonian2;uidinit=marge.simpsonian2;ENTPersonLogin=marge.simpsonian2@014",
+							"uid=marge.simpson2;uidinit=marge.simpson2;ENTPersonLogin=marge.simpson2@014",
+					}));
+			final String value = Functions.getInstance().executeAllFunctions(
+					"(UNICITY)" +
+							"ldap://ldap-pp.in.ac-rennes.fr:389/ou=personnes,dc=ent-bretagne,dc=fr??sub?" +
+							"(&(|(uid=marge.simpson*)(uidinit=marge.simpson*)(ENTPersonLogin=marge.simpson*@014))(territorycode=014))" +
+							"(/UNICITY)"
+			);
+			Assert.assertEquals("marge.simpson1", value);
+		} catch (final Exception e) {
+			System.out.println(e.getMessage());
+			Assert.fail();
+		}
+	}
+
+	/* test use case: check unicity function, multi-criteria, multi-pattern request, not evenly distributed sequential values, use next value */
+	@Test
+	public void test26() {
+		try {
+			// missing :
+			// uidinit=[marge.simpson1]
+			// ENTPersonLogin=[marge.simpson@014, marge.simpson3@014]
+			PowerMockito.when(mockedDirContext.search(Matchers.anyString(), Matchers.anyString(), Matchers.any(SearchControls.class))).
+					thenReturn(getResultSet(new String[] {
+							"uid=marge.simpson;uidinit=marge.simpson;ENTPersonLogin=marge.simpson1@014",
+							"uid=marge.simpson1;uidinit=marge.simpson2;ENTPersonLogin=marge.simpson2@014",
+							"uid=marge.simpson2;uidinit=marge.simpson3;ENTPersonLogin=marge.simpson4@014",
+					}));
+
+			final String value = Functions.getInstance().executeAllFunctions(
+					"(UNICITY)" +
+							"ldap://ldap-pp.in.ac-rennes.fr:389/ou=personnes,dc=ent-bretagne,dc=fr??sub?" +
+							"(&(|(uid=marge.simpson*)(uidinit=marge.simpson*)(ENTPersonLogin=marge.simpson*@014))(territorycode=014))" +
+							"(/UNICITY)"
+			);
+			Assert.assertEquals("marge.simpson5", value);
+		} catch (final Exception e) {
+			System.out.println(e.getMessage());
+			Assert.fail();
+		}
+	}
+
+
+	/* test use case: check unicity function, multi-criteria, multi-pattern request, not evenly distributed sequential values, fill the gap  */
+	@Test
+	public void test27() {
+		try {
+			// missing :
+			// uidinit=[marge.simpson1]
+			// ENTPersonLogin=[marge.simpson@014, marge.simpson3@014, marge.simpson4@014]
+			PowerMockito.when(mockedDirContext.search(Matchers.anyString(), Matchers.anyString(), Matchers.any(SearchControls.class))).
+					thenReturn(getResultSet(new String[] {
+							"uid=marge.simpson;uidinit=marge.simpson;ENTPersonLogin=marge.simpson1@014",
+							"uid=marge.simpson1;uidinit=marge.simpson2;ENTPersonLogin=marge.simpson2@014",
+							"uid=marge.simpson2;uidinit=marge.simpson3;ENTPersonLogin=marge.simpson5@014",
+					}));
+
+			final String value = Functions.getInstance().executeAllFunctions(
+					"(UNICITY)" +
+							"ldap://ldap-pp.in.ac-rennes.fr:389/ou=personnes,dc=ent-bretagne,dc=fr??sub?" +
+							"(&(|(uid=marge.simpson*)(uidinit=marge.simpson*)(ENTPersonLogin=marge.simpson*@014))(territorycode=014))" +
+							"(/UNICITY)"
+			);
+			Assert.assertEquals("marge.simpson4", value);
+		} catch (final Exception e) {
+			System.out.println(e.getMessage());
+			Assert.fail();
+		}
+	}
+
+	/* test use case: check unicity function, multi-criteria, multi-pattern request, not evenly distributed sequential values, use next value */
+	@Test
+	public void test28() {
+		try {
+			// missing :
+			// uid=[marge.simpson2, marge.simpson4]
+			// uidinit=[marge.simpson1, marge.simpson4, marge.simpson5]
+			// ENTPersonLogin=[marge.simpson2@014, marge.simpson3@014]
+			PowerMockito.when(mockedDirContext.search(Matchers.anyString(), Matchers.anyString(), Matchers.any(SearchControls.class))).
+					thenReturn(getResultSet(new String[] {
+							"uid=marge.simpson;uidinit=marge.simpson;ENTPersonLogin=marge.simpson@014",
+							"uid=marge.simpson1;uidinit=marge.simpson2;ENTPersonLogin=marge.simpson1@014",
+							"uid=marge.simpson3;uidinit=marge.simpson3;ENTPersonLogin=marge.simpson4@014",
+							"uid=marge.simpson5;uidinit=marge.simpson6;ENTPersonLogin=marge.simpson5@014"
+					}));
+
+			final String value = Functions.getInstance().executeAllFunctions(
+					"(UNICITY)" +
+							"ldap://ldap-pp.in.ac-rennes.fr:389/ou=personnes,dc=ent-bretagne,dc=fr??sub?" +
+							"(&(|(uid=marge.simpson*)(uidinit=marge.simpson*)(ENTPersonLogin=marge.simpson*@014))(territorycode=014))" +
+					  "(/UNICITY)"
+			);
+			Assert.assertEquals("marge.simpson7", value);
+		} catch (final Exception e) {
+			System.out.println(e.getMessage());
+			Assert.fail();
+		}
+	}
+
+	/* test use case: check unicity function, multi-criteria, multi-pattern request, not evenly distributed sequential values and invalid pattern, use next value */
+	@Test
+	public void test29() {
+		try {
+			// missing :
+			// uidinit=[marge.simpson1, marge.simpson4]
+			// ENTPersonLogin=[marge.simpson@014, marge.simpson3@014]
+			PowerMockito.when(mockedDirContext.search(Matchers.anyString(), Matchers.anyString(), Matchers.any(SearchControls.class))).
+					thenReturn(getResultSet(new String[] {
+							"uid=marge.simpson;uidinit=marge.simpson;ENTPersonLogin=marge.simpson1@014",
+							"uid=marge.simpson1;uidinit=marge.simpson2;ENTPersonLogin=marge.simpson2@014",
+							"uid=marge.simpson2;uidinit=marge.simpson3;ENTPersonLogin=marge.simpson4@014",
+					}));
+
+			// Pattern "marge.simpson@014*" for "ENTPersonLogin" is invalid as it does not share the same content of previous ones (marge.simpson*), it will be ignored.
+			final String value = Functions.getInstance().executeAllFunctions(
+					"(UNICITY)" +
+							"ldap://ldap-pp.in.ac-rennes.fr:389/ou=personnes,dc=ent-bretagne,dc=fr??sub?" +
+							"(&(|(uid=marge.simpson*)(uidinit=marge.simpson*)(ENTPersonLogin=marge.simpson@014*))(territorycode=014))" +
+							"(/UNICITY)"
+			);
+			// Do not reuse "marge.simpson4" as a value that matches the valid pattern (marge.simpson*) is already found for ENTPersonLogin=marge.simpson4@014
+			Assert.assertEquals("marge.simpson5", value);
+		} catch (final Exception e) {
+			System.out.println(e.getMessage());
+			Assert.fail();
+		}
+	}
+
+	/* test use case: check unicity function, multi-criteria, multi-pattern request, not evenly distributed sequential values and invalid pattern, use next value */
+	@Test
+	public void test30() {
+		try {
+			// missing :
+			// uidinit=[marge.simpson1]
+			// ENTPersonLogin=[marge.simpson1@014]
+			PowerMockito.when(mockedDirContext.search(Matchers.anyString(), Matchers.anyString(), Matchers.any(SearchControls.class))).
+					thenReturn(getResultSet(new String[] {
+							"uid=marge.simpson;uidinit=marge.simpson;ENTPersonLogin=marge.simpson@014",
+							"uid=marge.simpson1;uidinit=marge.simpson2;ENTPersonLogin=marge.simpson@017",
+							"uid=marge.simpson2;uidinit=marge.simpson3;ENTPersonLogin=marge.simpson2@014",
+					}));
+
+			// Pattern "marge.simpson@*" for "ENTPersonLogin" is invalid as it does not share the same content of previous ones (marge.simpson*), it will be ignored.
+			final String value = Functions.getInstance().executeAllFunctions(
+					"(UNICITY)" +
+							"ldap://ldap-pp.in.ac-rennes.fr:389/ou=personnes,dc=ent-bretagne,dc=fr??sub?" +
+							"(&(|(uid=marge.simpson*)(uidinit=marge.simpson*)(ENTPersonLogin=marge.simpson@*))(|(territorycode=014)(territorycode=017)))" +
+							"(/UNICITY)"
+			);
+			Assert.assertEquals("marge.simpson4", value);
+		} catch (final Exception e) {
+			System.out.println(e.getMessage());
+			Assert.fail();
+		}
+	}
+
+	/* test use case: check unicity function, multi-criteria, multi-pattern request, not evenly distributed sequential values and invalid pattern, use next value */
+	@Test
+	public void test31() {
+		try {
+			// missing :
+			// uidinit=[marge.simpson1]
+			// ENTPersonLogin=[marge.simpson1@014, marge.simpson3@014]
+			PowerMockito.when(mockedDirContext.search(Matchers.anyString(), Matchers.anyString(), Matchers.any(SearchControls.class))).
+					thenReturn(getResultSet(new String[] {
+							"uid=marge.simpson;uidinit=marge.simpson;ENTPersonLogin=marge.simpson@014",
+							"uid=marge.simpson1;uidinit=marge.simpson2;ENTPersonLogin=marge.simpson2@014",
+							"uid=marge.simpson2;uidinit=marge.simpson3;ENTPersonLogin=marge.simpson4@014",
+					}));
+
+			// Pattern "marge.simpson@*" for "ENTPersonLogin" is invalid as it does not share the same content of previous ones (marge.simpson*), it will be ignored.
+			final String value = Functions.getInstance().executeAllFunctions(
+					"(UNICITY)" +
+							"ldap://ldap-pp.in.ac-rennes.fr:389/ou=personnes,dc=ent-bretagne,dc=fr??sub?" +
+							"(&(|(uid=marge.simpson*)(uidinit=marge.simpson*)(ENTPersonLogin=marge.simpson@*))(territorycode=014))" +
+							"(/UNICITY)"
+			);
+			// Do not reuse "marge.simpson4" as a value that matches the valid pattern (marge.simpson*) is already found for ENTPersonLogin=marge.simpson4@014
+			Assert.assertEquals("marge.simpson5", value);
+		} catch (final Exception e) {
+			System.out.println(e.getMessage());
+			Assert.fail();
+		}
+	}
+
+	/* test use case: check unicity function, multi-criteria, multi-pattern request, not evenly distributed sequential values and a shorter invalid pattern, use next value */
+	@Test
+	public void test32() {
+		try {
+			// missing :
+			// uidinit=[marge.simpson1]
+			// ENTPersonLogin=[marge.simpson1@014, marge.simpson3@014]
+			PowerMockito.when(mockedDirContext.search(Matchers.anyString(), Matchers.anyString(), Matchers.any(SearchControls.class))).
+					thenReturn(getResultSet(new String[] {
+							"uid=marge.simpson;uidinit=marge.simpson;ENTPersonLogin=marge.simpson@014",
+							"uid=marge.simpson1;uidinit=marge.simpson2;ENTPersonLogin=marge.simpson2@014",
+							"uid=marge.simpson2;uidinit=marge.simpson3;ENTPersonLogin=marge.simpson4@014", // matching ENTPersonLogin
+					}));
+
+			// Pattern "marge*" for "ENTPersonLogin" is invalid as it does not share the same content of previous ones (marge.simpson*), it will be ignored.
+			final String value = Functions.getInstance().executeAllFunctions(
+					"(UNICITY)" +
+							"ldap://ldap-pp.in.ac-rennes.fr:389/ou=personnes,dc=ent-bretagne,dc=fr??sub?" +
+							"(&(|(uid=marge.simpson*)(uidinit=marge.simpson*)(ENTPersonLogin=marge*))(territorycode=014))" +
+							"(/UNICITY)"
+			);
+			// Do not reuse "marge.simpson4" as a value that matches the valid pattern (marge.simpson*) is already found for ENTPersonLogin=marge*
+			Assert.assertEquals("marge.simpson5", value);
+		} catch (final Exception e) {
+			System.out.println(e.getMessage());
+			Assert.fail();
+		}
+	}
+
+	/* test use case: check unicity function, multi-criteria, multi-pattern request, not evenly distributed sequential values and a shorted invalid pattern, use next value */
+	@Test
+	public void test33() {
+		try {
+			// missing :
+			// uidinit=[marge.simpson1]
+			// ENTPersonLogin=[marge.simpson1@014]
+			PowerMockito.when(mockedDirContext.search(Matchers.anyString(), Matchers.anyString(), Matchers.any(SearchControls.class))).
+					thenReturn(getResultSet(new String[] {
+							"uid=marge.simpson;uidinit=marge.simpson;ENTPersonLogin=marge.simpson@014",
+							"uid=marge.simpson1;uidinit=marge.simpson2;ENTPersonLogin=marge.simpson2@014",
+							"uid=marge.simpson2;uidinit=marge.simpson3;ENTPersonLogin=marge.simpsonian@014", // not matching ENTPersonLogin
+					}));
+
+			// Pattern "marge*" for "ENTPersonLogin" is invalid as it does not share the same content of previous ones (marge.simpson*), it will be ignored.
+			final String value = Functions.getInstance().executeAllFunctions(
+					"(UNICITY)" +
+							"ldap://ldap-pp.in.ac-rennes.fr:389/ou=personnes,dc=ent-bretagne,dc=fr??sub?" +
+							"(&(|(uid=marge.simpson*)(uidinit=marge.simpson*)(ENTPersonLogin=marge*))(territorycode=014))" +
+							"(/UNICITY)"
+			);
+			Assert.assertEquals("marge.simpson4", value);
+		} catch (final Exception e) {
+			System.out.println(e.getMessage());
+			Assert.fail();
+		}
+	}
+
+	/* test use case: check unicity function, multi-criteria, multi-pattern request, not evenly distributed sequential values and invalid pattern, fill the gap */
+	@Test
+	public void test34() {
+		try {
+			// missing :
+			// uidinit=[marge.simpson1]
+			// ENTPersonLogin=[marge.simpson1@014, marge.simpson4@014]
+			PowerMockito.when(mockedDirContext.search(Matchers.anyString(), Matchers.anyString(), Matchers.any(SearchControls.class))).
+					thenReturn(getResultSet(new String[] {
+							"uid=marge.simpson;uidinit=marge.simpson;ENTPersonLogin=marge.simpson@014",
+							"uid=marge.simpson1;uidinit=marge.simpson2;ENTPersonLogin=marge.simpson@017",
+							"uid=marge.simpson2;uidinit=marge.simpson3;ENTPersonLogin=marge.simpson5@014",
+					}));
+
+			// Pattern "marge.simpson@*" for "ENTPersonLogin" is invalid as it does not share the same content of previous ones (marge.simpson*), it will be ignored.
+			final String value = Functions.getInstance().executeAllFunctions(
+					"(UNICITY)" +
+							"ldap://ldap-pp.in.ac-rennes.fr:389/ou=personnes,dc=ent-bretagne,dc=fr??sub?" +
+							"(&(|(uid=marge.simpson*)(uidinit=marge.simpson*)(ENTPersonLogin=marge.simpson@*))(|(territorycode=014)(territorycode=017)))" +
+							"(/UNICITY)"
+			);
+			Assert.assertEquals("marge.simpson4", value);
+		} catch (final Exception e) {
+			System.out.println(e.getMessage());
+			Assert.fail();
+		}
+	}
+
+	/* test use case: check unicity function, multi-criteria, multi-pattern request, not evenly distributed sequential values and invalid pattern, use next value */
+	@Test
+	public void test35() {
+		try {
+			// missing :
+			// uidinit=[marge.simpson1]
+			// ENTPersonLogin=[marge.simpson1@014, marge.simpson4@014, marge.simpson@017, marge.simpson1@017, marge.simpson2@017, marge.simpson3@017]
+			PowerMockito.when(mockedDirContext.search(Matchers.anyString(), Matchers.anyString(), Matchers.any(SearchControls.class))).
+					thenReturn(getResultSet(new String[] {
+							"uid=marge.simpson;uidinit=marge.simpson;ENTPersonLogin=marge.simpson@014",
+							"uid=marge.simpson1;uidinit=marge.simpson2;ENTPersonLogin=marge.simpson4@017",
+							"uid=marge.simpson2;uidinit=marge.simpson3;ENTPersonLogin=marge.simpson5@014",
+					}));
+
+			// Pattern "marge.simpson@*" for "ENTPersonLogin" is invalid as it does not share the same content of previous ones (marge.simpson*), it will be ignored.
+			final String value = Functions.getInstance().executeAllFunctions(
+					"(UNICITY)" +
+							"ldap://ldap-pp.in.ac-rennes.fr:389/ou=personnes,dc=ent-bretagne,dc=fr??sub?" +
+							"(&(|(uid=marge.simpson*)(uidinit=marge.simpson*)(ENTPersonLogin=marge.simpson@*))(|(territorycode=014)(territorycode=017)))" +
+							"(/UNICITY)"
+			);
+			// Do not reuse "marge.simpson4" as a value that matches the valid pattern (marge.simpson*) is already found for ENTPersonLogin=marge.simpson4@017
+			Assert.assertEquals("marge.simpson6", value);
+		} catch (final Exception e) {
+			System.out.println(e.getMessage());
+			Assert.fail();
+		}
+	}
+
+	/* test use case: check unicity function, multi-criteria, multi-pattern request, not evenly distributed sequential values and invalid pattern, fill the gap */
+	@Test
+	public void test36() {
+		try {
+			// missing :
+			// uidinit=[marge.simpson1]
+			// ENTPersonLogin=[marge.simpson1@014, marge.simpson4@014, marge.simpson5@014, marge.simpson@017, marge.simpson1@017, marge.simpson2@017, marge.simpson3@017]
+			PowerMockito.when(mockedDirContext.search(Matchers.anyString(), Matchers.anyString(), Matchers.any(SearchControls.class))).
+					thenReturn(getResultSet(new String[] {
+							"uid=marge.simpson;uidinit=marge.simpson;ENTPersonLogin=marge.simpson@014",
+							"uid=marge.simpson1;uidinit=marge.simpson2;ENTPersonLogin=marge.simpson4@017",
+							"uid=marge.simpson2;uidinit=marge.simpson3;ENTPersonLogin=marge.simpson6@014",
+					}));
+
+			// Pattern "marge.simpson@*" for "ENTPersonLogin" is invalid as it does not share the same content of previous ones (marge.simpson*), it will be ignored.
+			final String value = Functions.getInstance().executeAllFunctions(
+					"(UNICITY)" +
+							"ldap://ldap-pp.in.ac-rennes.fr:389/ou=personnes,dc=ent-bretagne,dc=fr??sub?" +
+							"(&(|(uid=marge.simpson*)(uidinit=marge.simpson*)(ENTPersonLogin=marge.simpson@*))(|(territorycode=014)(territorycode=017)))" +
+							"(/UNICITY)"
+			);
+			Assert.assertEquals("marge.simpson5", value);
+		} catch (final Exception e) {
+			System.out.println(e.getMessage());
+			Assert.fail();
+		}
+	}
 }

--- a/product/src/test/java/fr/gouv/education/acrennes/alambic/freemarker/FunctionsTest.java
+++ b/product/src/test/java/fr/gouv/education/acrennes/alambic/freemarker/FunctionsTest.java
@@ -828,4 +828,128 @@ public class FunctionsTest {
 			Assert.fail();
 		}
 	}
+
+	// Following tests use * at the beginning of each pattern
+
+	/* test use case: check unicity function, multi-criteria, multi-pattern request, happy path with evenly distributed sequential values, use next value */
+	@Test
+	public void test37() {
+		try {
+			PowerMockito.when(mockedDirContext.search(Matchers.anyString(), Matchers.anyString(), Matchers.any(SearchControls.class))).
+					thenReturn(getResultSet(new String[] {
+							"uid=marge.simpson;uidinit=marge.simpson;ENTPersonLogin=marge.simpson@014",
+							"uid=jacqueline.simpson;uidinit=jacqueline.simpson;ENTPersonLogin=jacqueline.simpson@014",
+							"uid=marge.jacqueline.simpson;uidinit=marge.jacqueline.simpson;ENTPersonLogin=marge.jacqueline.simpson@014",
+					}));
+			final String value = Functions.getInstance().executeAllFunctions(
+					"(UNICITY)" +
+							"ldap://ldap-pp.in.ac-rennes.fr:389/ou=personnes,dc=ent-bretagne,dc=fr??sub?" +
+							"(&(|(uid=*marge.simpson)(uidinit=*marge.simpson)(ENTPersonLogin=*marge.simpson@014))(|territorycode=014)" +
+							"(/UNICITY)"
+			);
+			Assert.assertEquals("1marge.simpson", value);
+		} catch (final Exception e) {
+			System.out.println(e.getMessage());
+			Assert.fail();
+		}
+	}
+
+	/* test use case: check unicity function, multi-criteria, multi-pattern request, happy path with evenly distributed sequential values, use next value */
+	@Test
+	public void test38() {
+		try {
+			PowerMockito.when(mockedDirContext.search(Matchers.anyString(), Matchers.anyString(), Matchers.any(SearchControls.class))).
+					thenReturn(getResultSet(new String[] {
+							"uid=jacqueline.simpson;uidinit=jacqueline.simpson;ENTPersonLogin=jacqueline.simpson@014",
+							"uid=marge.jacqueline.simpson;uidinit=marge.jacqueline.simpson;ENTPersonLogin=marge.jacqueline.simpson@014",
+					}));
+
+			final String value = Functions.getInstance().executeAllFunctions(
+					"(UNICITY)" +
+							"ldap://ldap-pp.in.ac-rennes.fr:389/ou=personnes,dc=ent-bretagne,dc=fr??sub?" +
+							"(&(|(uid=*jacqueline.simpson)(uidinit=*jacqueline.simpson)(ENTPersonLogin=*jacqueline.simpson@014))(|territorycode=014)" +
+							"(/UNICITY)"
+			);
+			Assert.assertEquals("1jacqueline.simpson", value);
+		} catch (final Exception e) {
+			System.out.println(e.getMessage());
+			Assert.fail();
+		}
+	}
+
+	/* test use case: check unicity function, multi-criteria, multi-pattern request, happy path with evenly distributed sequential values, use next value */
+	@Test
+	public void test40() {
+		try {
+			PowerMockito.when(mockedDirContext.search(Matchers.anyString(), Matchers.anyString(), Matchers.any(SearchControls.class))).
+					thenReturn(getResultSet(new String[] {
+							"uid=marge.jacqueline.simpson;uidinit=marge.jacqueline.simpson;ENTPersonLogin=marge.jacqueline.simpson@014",
+							"uid=1marge.jacqueline.simpson;uidinit=1marge.jacqueline.simpson;ENTPersonLogin=1marge.jacqueline.simpson@014",
+					}));
+			final String value = Functions.getInstance().executeAllFunctions(
+					"(UNICITY)" +
+							"ldap://ldap-pp.in.ac-rennes.fr:389/ou=personnes,dc=ent-bretagne,dc=fr??sub?" +
+							"(&(|(uid=*marge.jacqueline.simpson)(uidinit=*marge.jacqueline.simpson)(ENTPersonLogin=*marge.jacqueline.simpson@014))(|territorycode=014)" +
+							"(/UNICITY)"
+			);
+			Assert.assertEquals("2marge.jacqueline.simpson", value);
+		} catch (final Exception e) {
+			System.out.println(e.getMessage());
+			Assert.fail();
+		}
+	}
+
+	/* test use case: check unicity function, multi-criteria, multi-pattern request, happy path with evenly distributed sequential values, fill the gap */
+	@Test
+	public void test41() {
+		try {
+			// missing :
+			// uid=[jacqueline.simpson]
+			// uidinit=[jacqueline.simpson]
+			// ENTPersonLogin=[jacqueline.simpson@014]
+			PowerMockito.when(mockedDirContext.search(Matchers.anyString(), Matchers.anyString(), Matchers.any(SearchControls.class))).
+					thenReturn(getResultSet(new String[] {
+							"uid=1jacqueline.simpson;uidinit=1jacqueline.simpson;ENTPersonLogin=1jacqueline.simpson@014",
+							"uid=2jacqueline.simpson;uidinit=2jacqueline.simpson;ENTPersonLogin=2jacqueline.simpson@014",
+					}));
+			final String value = Functions.getInstance().executeAllFunctions(
+					"(UNICITY)" +
+							"ldap://ldap-pp.in.ac-rennes.fr:389/ou=personnes,dc=ent-bretagne,dc=fr??sub?" +
+							"(&(|(uid=*jacqueline.simpson)(uidinit=*jacqueline.simpson)(ENTPersonLogin=*jacqueline.simpson@014))(|territorycode=014)" +
+							"(/UNICITY)"
+			);
+			// we reuse missing value
+			Assert.assertEquals("jacqueline.simpson", value);
+		} catch (final Exception e) {
+			System.out.println(e.getMessage());
+			Assert.fail();
+		}
+	}
+
+	/* test use case: check unicity function, multi-criteria, multi-pattern request, not evenly distributed sequential values, fill the gap */
+	@Test
+	public void test42() {
+		try {
+			// missing :
+			// uid=[1jacqueline.simpson]
+			// uidinit=[jacqueline.simpson, 1jacqueline.simpson, 3jacqueline.simpson]
+			// ENTPersonLogin=[jacqueline.simpson@014, 1jacqueline.simpson@014, 2jacqueline.simpson@014]
+			PowerMockito.when(mockedDirContext.search(Matchers.anyString(), Matchers.anyString(), Matchers.any(SearchControls.class))).
+					thenReturn(getResultSet(new String[] {
+							"uid=2jacqueline.simpson;uidinit=2jacqueline.simpson;ENTPersonLogin=3jacqueline.simpson@014",
+							"uid=jacqueline.simpson;uidinit=4jacqueline.simpson;ENTPersonLogin=jacqueline.simpson@014",
+					}));
+			final String value = Functions.getInstance().executeAllFunctions(
+					"(UNICITY)" +
+							"ldap://ldap-pp.in.ac-rennes.fr:389/ou=personnes,dc=ent-bretagne,dc=fr??sub?" +
+							"(&(|(uid=*jacqueline.simpson)(uidinit=*jacqueline.simpson)(ENTPersonLogin=*jacqueline.simpson@014))(|territorycode=014)" +
+							"(/UNICITY)"
+			);
+			// we reuse missing value
+			Assert.assertEquals("1jacqueline.simpson", value);
+		} catch (final Exception e) {
+			System.out.println(e.getMessage());
+			Assert.fail();
+		}
+	}
 }


### PR DESCRIPTION
Allow different patterns for multiple criteria requests, as long as the given patterns share a common part. 
Returned value will be calculated using that common fragment of the defined patterns